### PR TITLE
JDK21 support, fix Unirest erroneously spawning threads, upgrade dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,14 @@
 group = "dev.klepto.kweb3"
 version = "0.0.1"
 
+plugins {
+    id("io.freefair.lombok") version "8.6" apply false
+}
+
 subprojects {
     apply {
         plugin("java-library")
+        plugin("io.freefair.lombok")
     }
 
     repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,24 @@
 [versions]
 slf4j = "2.0.5"
-kotlin = "1.9.22"
-unirest = "4.3.1"
+kotlin = "1.9.24"
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.0" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.9.1" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
-google-guava = { module = "com.google.guava:guava", version = "32.0.0-jre" }
-google-gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
-headlong = { module = "com.esaulpaugh:headlong", version = "9.1.1" }
+google-guava = { module = "com.google.guava:guava", version = "33.2.0-jre" }
+google-gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
+headlong = { module = "com.esaulpaugh:headlong", version = "11.1.0" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
-java-websocket = { module = "org.java-websocket:Java-WebSocket", version = "1.5.4" }
+java-websocket = { module = "org.java-websocket:Java-WebSocket", version = "1.5.6" }
 unreflect = { module = "dev.klepto.unreflect:unreflect", version = "1.5" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }
-unirest-core = { module = "com.konghq:unirest-java-core", version.ref = "unirest" }
-unirest-gson = { module = "com.konghq:unirest-modules-gson", version.ref = "unirest" }
+kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.8.1" }
+
+unirest-bom = { module = "com.konghq:unirest-java-bom", version = "4.4.0" }
+unirest-core = { module = "com.konghq:unirest-java-core" }
+unirest-gson = { module = "com.konghq:unirest-modules-gson" }
 
 [bundles]
 slf4j = ["slf4j-api", "slf4j-simple"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ unirest = "4.3.1"
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.0" }
 junit-bom = { module = "org.junit:junit-bom", version = "5.9.1" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
-lombok = { module = "org.projectlombok:lombok", version = "1.18.24" }
 google-guava = { module = "com.google.guava:guava", version = "32.0.0-jre" }
 google-gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
 headlong = { module = "com.esaulpaugh:headlong", version = "9.1.1" }

--- a/kweb3-core/build.gradle.kts
+++ b/kweb3-core/build.gradle.kts
@@ -2,7 +2,6 @@ dependencies {
     api(libs.unreflect)
     api(libs.google.guava)
 
-
     implementation(libs.jetbrains.annotations)
     implementation(libs.google.gson)
     implementation(libs.headlong)
@@ -13,10 +12,6 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
-
-    implementation(libs.lombok)
-    annotationProcessor(libs.lombok)
-    testAnnotationProcessor(libs.lombok)
 }
 
 tasks.test {

--- a/kweb3-core/build.gradle.kts
+++ b/kweb3-core/build.gradle.kts
@@ -7,6 +7,8 @@ dependencies {
     implementation(libs.headlong)
     implementation(libs.java.websocket)
     implementation(libs.bundles.slf4j)
+
+    implementation(platform(libs.unirest.bom))
     implementation(libs.unirest.core)
     implementation(libs.unirest.gson)
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/abi/HeadlongCodec.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/abi/HeadlongCodec.java
@@ -322,7 +322,7 @@ public class HeadlongCodec implements AbiCodec {
         for (var i = 0; i < values.length; i++) {
             values[i] = encodeValue(value.get(i));
         }
-        return Tuple.of(values);
+        return Tuple.from(values);
     }
 
 }

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/RpcClient.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/RpcClient.java
@@ -89,7 +89,7 @@ public class RpcClient implements Closeable, EthProtocol {
     }
 
     /**
-     * Called when connection is closed. Selects next endpoint in the list.
+     * Called when connection is closed.
      */
     private void onClose() {
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/io/HttpRpcConnection.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/io/HttpRpcConnection.java
@@ -65,4 +65,10 @@ public class HttpRpcConnection extends AuthorizedRpcConnection {
         });
     }
 
+    @Override
+    public void close() {
+        unirest.close();
+        super.close();
+    }
+
 }

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/io/HttpRpcConnection.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/io/HttpRpcConnection.java
@@ -51,7 +51,7 @@ public class HttpRpcConnection extends AuthorizedRpcConnection {
 
         val timeout = endpoint.settings().requestTimeout();
         if (timeout != null) {
-            request = request.connectTimeout((int) timeout.toMillis());
+            request = request.requestTimeout((int) timeout.toMillis());
         }
 
         request.asStringAsync().whenComplete((response, throwable) -> {

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/io/HttpRpcConnection.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/io/HttpRpcConnection.java
@@ -2,10 +2,7 @@ package dev.klepto.kweb3.core.ethereum.rpc.io;
 
 import dev.klepto.kweb3.core.chain.Web3Endpoint;
 import dev.klepto.kweb3.core.ethereum.rpc.RpcMessage;
-import kong.unirest.core.Config;
-import kong.unirest.core.ContentType;
-import kong.unirest.core.FailedResponse;
-import kong.unirest.core.UnirestInstance;
+import kong.unirest.core.*;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,8 +16,6 @@ import java.util.function.Consumer;
  * @author <a href="http://github.com/klepto">Augustinas R.</a>
  */
 public class HttpRpcConnection extends AuthorizedRpcConnection {
-
-    private final UnirestInstance unirest = new UnirestInstance(new Config());
 
     /**
      * Constructs a new {@link HttpRpcConnection} for the specified endpoint.
@@ -45,7 +40,7 @@ public class HttpRpcConnection extends AuthorizedRpcConnection {
     @Override
     public void send(String message) {
         val endpoint = authorizedEndpoint();
-        var request = unirest.post(endpoint.url())
+        var request = Unirest.post(endpoint.url())
                 .contentType(ContentType.APPLICATION_JSON)
                 .body(message);
 
@@ -63,12 +58,6 @@ public class HttpRpcConnection extends AuthorizedRpcConnection {
                 receive(response.getBody());
             }
         });
-    }
-
-    @Override
-    public void close() {
-        unirest.close();
-        super.close();
     }
 
 }

--- a/kweb3-kotlin/build.gradle.kts
+++ b/kweb3-kotlin/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(17)
     compilerOptions {
         freeCompilerArgs.add("-Xjvm-default=all")
     }


### PR DESCRIPTION
- Support JDK21, the toolchain requirement in the build made compiling with any other version impossible. Let the consumer decide which JDK to use.
- Upgrade all dependencies. Only 2 breaking changes.
  - Unirest: `HttpRequest#connectTimeout` to `HttpRequest#requestTimeout`
  - Headlong: `Tuple.of` to `Tuple.from`
- Use the Lombok Gradle plugin over manual dependency configuration
- Use the provided singleton instance of Unirest. The backing thread-pool provided by default is plenty. In future we could support configuring of the Unirest client, for now, this is more than sufficient.
- Use the Unirest BOM for dependency management similar to the JUnit BOM