### PR TITLE
Overflow-concious primitive conversions, modular exponentiation and re-usable constants

### DIFF
--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/EthNumericValue.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/EthNumericValue.java
@@ -139,7 +139,47 @@ public interface EthNumericValue<T extends EthValue> extends EthValue, Comparabl
     }
 
     /**
-     * Returns numeric value as {@link BigDecimal}> value with <code>18</code> decimals.
+     * Returns the value of this numeric value, throwing an exception if the value overflows a {@code long}.
+     *
+     * @return the argument as a {@code long}.
+     * @throws ArithmeticException if the {@code argument} overflows an long
+     */
+    default long longValueExact() {
+        return value().longValueExact();
+    }
+
+    /**
+     * Returns the value of this numeric value, throwing an exception if the value overflows an {@code int}.
+     *
+     * @return the argument as an {@code int}.
+     * @throws ArithmeticException if the {@code argument} overflows an int
+     */
+    default int intValueExact() {
+        return value().intValueExact();
+    }
+
+    /**
+     * Returns the value of this numeric value, throwing an exception if the value overflows a {@code short}.
+     *
+     * @return the argument as a {@code short}.
+     * @throws ArithmeticException if the {@code argument} overflows a short
+     */
+    default short shortValueExact() {
+        return value().shortValueExact();
+    }
+
+    /**
+     * Returns the value of this numeric value, throwing an exception if the value overflows a {@code byte}.
+     *
+     * @return the argument as a {@code byte}.
+     * @throws ArithmeticException if the {@code argument} overflows a byte
+     */
+    default byte byteValueExact() {
+        return value().byteValueExact();
+    }
+
+    /**
+     * Returns numeric value as {@link BigDecimal} value with <code>18</code> decimals.
      *
      * @return the numeric value as big decimal with 18 decimal places
      */

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
@@ -24,7 +24,22 @@ public class EthInt extends Number implements EthValue, EthNumericValue<EthInt>,
     /**
      * Zero <code>ethereum int</code> constant.
      */
-    public static final EthInt ZERO = int256(0);
+    public static final EthInt ZERO = int256(BigInteger.ZERO);
+
+    /**
+     * One <code>ethereum int</code> constant.
+     */
+    public static final EthInt ONE = int256(BigInteger.ONE);
+
+    /**
+     * Two <code>ethereum int</code> constant.
+     */
+    public static final EthInt TWO = int256(BigInteger.TWO);
+
+    /**
+     * Ten <code>ethereum int</code> constant.
+     */
+    public static final EthInt TEN = int256(BigInteger.TEN);
 
     private final int size;
     private final BigInteger value;

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthInt.java
@@ -137,6 +137,24 @@ public class EthInt extends Number implements EthValue, EthNumericValue<EthInt>,
     }
 
     /**
+     * Performs modular exponentiation on this {@link EthInt} instance with the specified exponent,
+     * using a modulus of <code>2^{@link EthInt#size}</code> This method is particularly useful for cryptographic
+     * operations where calculations need to wrap around at the boundary of <code>2^{@link EthInt#size}</code> to
+     * prevent integer overflow and ensure values remain within the {@link EthInt#size} bit limit.
+     *
+     * @param exponent The {@link EthUint} representing the exponent to which this value is raised.
+     * @return A new {@link EthUint} object representing <code>this^exponent % 2^{@link EthInt#size}</code>.
+     * @throws ArithmeticException If the <code>exponent</code> is negative and this EthInt is not relatively prime to
+     *                             <code>2^{@link EthInt#size}</code>
+     */
+    public @NotNull EthInt pow(@NotNull EthUint exponent) {
+        // BigInteger.ONE.shiftLeft(size) computes 2^size, providing the modulus for the operation.
+        BigInteger modulus = BigInteger.ONE.shiftLeft(size);
+        return withValue(value.modPow(exponent.value(), modulus));
+    }
+
+
+    /**
      * Returns string representation of this <code>ethereum int</code>.
      *
      * @return string representation of this <code>ethereum int</code>

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
@@ -24,7 +24,22 @@ public class EthUint extends Number implements EthValue, EthNumericValue<EthUint
     /**
      * Zero <code>uint</code> constant.
      */
-    public static final EthUint ZERO = uint256(0);
+    public static final EthUint ZERO = uint256(BigInteger.ZERO);
+
+    /**
+     * One <code>uint</code> constant.
+     */
+    public static final EthUint ONE = uint256(BigInteger.ONE);
+
+    /**
+     * Two <code>uint</code> constant.
+     */
+    public static final EthUint TWO = uint256(BigInteger.TWO);
+
+    /**
+     * Ten <code>uint</code> constant.
+     */
+    public static final EthUint TEN = uint256(BigInteger.TEN);
 
     private final int size;
 

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/type/primitive/EthUint.java
@@ -138,6 +138,21 @@ public class EthUint extends Number implements EthValue, EthNumericValue<EthUint
     }
 
     /**
+     * Performs modular exponentiation on this {@link EthUint} instance with the specified exponent,
+     * using a modulus of <code>2^{@link EthUint#size}</code> This method is particularly useful for cryptographic operations
+     * where calculations need to wrap around at the boundary of <code>2^{@link EthUint#size}</code> to prevent integer overflow
+     * and ensure values remain within the {@link EthUint#size} bit limit.
+     *
+     * @param exponent The {@link EthUint} representing the exponent to which this value is raised.
+     * @return A new {@link EthUint} object representing <code>this^exponent % 2^{@link EthUint#size}</code>.
+     */
+    public @NotNull EthUint pow(@NotNull EthUint exponent) {
+        // BigInteger.ONE.shiftLeft(size) computes 2^size, providing the modulus for the operation.
+        BigInteger modulus = BigInteger.ONE.shiftLeft(size);
+        return withValue(value.modPow(exponent.value(), modulus));
+    }
+
+    /**
      * Returns string representation of this <code>ethereum uint</code>.
      *
      * @return string representation of this <code>ethereum uint</code>


### PR DESCRIPTION
- Adds `EthNumericValue#{primitive}ValueExact` which are conversions from `EthNumericValue` to the specified primitive, or throwing an arithmetic exception if the value cannot be stored in the aforementioned primitive.
- Adds constant values `ONE`, `TWO` and `TEN` as we have found they are commonly used in various math equations and exponentiation.
- Adds modular exponentiation to `EthUint` and `EthInt`