### PR TITLE
feat(quick and dirty): bundle internal rpc connection consumers with …

### DIFF
--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/Web3Client.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/Web3Client.java
@@ -4,10 +4,12 @@ import dev.klepto.kweb3.core.chain.Web3Chain;
 import dev.klepto.kweb3.core.chain.Web3Endpoint;
 import dev.klepto.kweb3.core.contract.*;
 import dev.klepto.kweb3.core.ethereum.EthereumClient;
+import dev.klepto.kweb3.core.ethereum.rpc.RpcClientListener;
 import dev.klepto.kweb3.core.ethereum.type.primitive.EthAddress;
 import lombok.Getter;
 import lombok.experimental.Delegate;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 
@@ -35,29 +37,25 @@ public class Web3Client implements Closeable {
      * @param contractExecutor the contract executor
      * @param contractParser   the contract parser
      * @param endpoint         the endpoints this client connects to
+     * @param listener         the listener for the client
      */
     public Web3Client(@NotNull ContractProvider contractProvider,
                       @NotNull ContractExecutor contractExecutor,
                       @NotNull ContractParser contractParser,
-                      @NotNull Web3Endpoint endpoint) {
+                      @NotNull Web3Endpoint endpoint,
+                      @Nullable RpcClientListener listener) {
         this.contractProvider = contractProvider;
         this.contractExecutor = contractExecutor;
         this.contractParser = contractParser;
         this.address = EthAddress.ZERO;
-        this.ethereum = new EthereumClient(endpoint);
+        this.ethereum = new EthereumClient(endpoint, listener);
     }
 
-    /**
-     * Creates a new client instance for the given endpoints.
-     *
-     * @param endpoint the endpoints this client connects to
-     */
-    public Web3Client(@NotNull Web3Endpoint endpoint) {
-        this.contractProvider = new ContractProxyProvider();
-        this.contractExecutor = new ReflectionContractExecutor();
-        this.contractParser = new ReflectionContractParser();
-        this.address = EthAddress.ZERO;
-        this.ethereum = new EthereumClient(endpoint);
+    public Web3Client(@NotNull ContractProvider contractProvider,
+                      @NotNull ContractExecutor contractExecutor,
+                      @NotNull ContractParser contractParser,
+                      @NotNull Web3Endpoint endpoint) {
+        this(contractProvider, contractExecutor, contractParser, endpoint, null);
     }
 
     /**

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/EthereumClient.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/EthereumClient.java
@@ -3,9 +3,11 @@ package dev.klepto.kweb3.core.ethereum;
 import dev.klepto.kweb3.core.Web3Result;
 import dev.klepto.kweb3.core.chain.Web3Endpoint;
 import dev.klepto.kweb3.core.ethereum.rpc.RpcClient;
+import dev.klepto.kweb3.core.ethereum.rpc.RpcClientListener;
 import dev.klepto.kweb3.core.ethereum.type.data.EthBlock;
 import dev.klepto.kweb3.core.ethereum.type.primitive.EthUint;
 import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 
@@ -24,8 +26,12 @@ public class EthereumClient implements Closeable {
      *
      * @param endpoint the RPC endpoints
      */
+    public EthereumClient(Web3Endpoint endpoint, @Nullable RpcClientListener listener) {
+        this.rpc = new RpcClient(endpoint, listener);
+    }
+
     public EthereumClient(Web3Endpoint endpoint) {
-        this.rpc = new RpcClient(endpoint);
+        this(endpoint, null);
     }
 
     /**

--- a/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/RpcClientListener.java
+++ b/kweb3-core/src/main/java/dev/klepto/kweb3/core/ethereum/rpc/RpcClientListener.java
@@ -1,0 +1,11 @@
+package dev.klepto.kweb3.core.ethereum.rpc;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface RpcClientListener {
+    void onMessage(@NotNull RpcMessage message);
+
+    void onError(@NotNull Throwable throwable);
+
+    void onClose();
+}

--- a/kweb3-kotlin/src/main/kotlin/dev/klepto/kweb3/kotlin/CoroutineWeb3Client.kt
+++ b/kweb3-kotlin/src/main/kotlin/dev/klepto/kweb3/kotlin/CoroutineWeb3Client.kt
@@ -3,6 +3,7 @@ package dev.klepto.kweb3.kotlin
 import dev.klepto.kweb3.core.Web3Client
 import dev.klepto.kweb3.core.chain.Web3Endpoint
 import dev.klepto.kweb3.core.contract.*
+import dev.klepto.kweb3.core.ethereum.rpc.RpcClientListener
 import dev.klepto.kweb3.core.ethereum.type.primitive.EthAddress
 
 /**
@@ -16,12 +17,14 @@ open class CoroutineWeb3Client(
     contractProvider: ContractProvider = ContractProxyProvider(),
     contractExecutor: ContractExecutor = CoroutineContractExecutor(),
     contractParser: ContractParser = CoroutineContractParser(),
+    listener: RpcClientListener? = null
 ) :
     Web3Client(
         contractProvider,
         contractExecutor,
         contractParser,
-        endpoint
+        endpoint,
+        listener
     ) {
 
     companion object {


### PR DESCRIPTION
…new `RpcClientListener` which bubbles up all message/close/error handlers for external use